### PR TITLE
No Contact form version 

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,65 +184,11 @@
         </div>
     </section>
 
-    <!-- Contact Section -->
-    <section id="contact">
-        <div class="container">
-            <div class="row">
-                <div class="col-lg-12 text-center">
-                    <h2>Contact Me</h2>
-                    <hr class="star-primary">
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-lg-8 col-lg-offset-2">
-                    <!-- To configure the contact form email address, go to mail/contact_me.php and update the email address in the PHP file on line 19. -->
-                    <!-- The form should work on most web servers, but if the form is not working you may need to configure your web server differently. -->
-                    <form name="sentMessage" id="contactForm" novalidate>
-                        <div class="row control-group">
-                            <div class="form-group col-xs-12 floating-label-form-group controls">
-                                <label>Name</label>
-                                <input type="text" class="form-control" placeholder="Name" id="name" required data-validation-required-message="Please enter your name.">
-                                <p class="help-block text-danger"></p>
-                            </div>
-                        </div>
-                        <div class="row control-group">
-                            <div class="form-group col-xs-12 floating-label-form-group controls">
-                                <label>Email Address</label>
-                                <input type="email" class="form-control" placeholder="Email Address" id="email" required data-validation-required-message="Please enter your email address.">
-                                <p class="help-block text-danger"></p>
-                            </div>
-                        </div>
-                        <div class="row control-group">
-                            <div class="form-group col-xs-12 floating-label-form-group controls">
-                                <label>Phone Number</label>
-                                <input type="tel" class="form-control" placeholder="Phone Number" id="phone" required data-validation-required-message="Please enter your phone number.">
-                                <p class="help-block text-danger"></p>
-                            </div>
-                        </div>
-                        <div class="row control-group">
-                            <div class="form-group col-xs-12 floating-label-form-group controls">
-                                <label>Message</label>
-                                <textarea rows="5" class="form-control" placeholder="Message" id="message" required data-validation-required-message="Please enter a message."></textarea>
-                                <p class="help-block text-danger"></p>
-                            </div>
-                        </div>
-                        <br>
-                        <div id="success"></div>
-                        <div class="row">
-                            <div class="form-group col-xs-12">
-                                <button type="submit" class="btn btn-success btn-lg">Send</button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-        </div>
-    </section>
-
     <!-- Footer -->
     <footer class="text-center">
         <div class="footer-above">
             <div class="container">
+                <div id="contact">
                 <div class="row">
                     <div class="footer-col col-md-4">
                         <h3>Location</h3>
@@ -266,6 +212,9 @@
                             <li>
                                 <a href="#" class="btn-social btn-outline"><i class="fa fa-fw fa-dribbble"></i></a>
                             </li>
+                            <li>
+                                <a href="#" class ="btn-social btn-outline"><i class="fa fa-fw fa-envelope"></i></a>
+                            </li>
                         </ul>
                     </div>
                     <div class="footer-col col-md-4">
@@ -282,6 +231,7 @@
                         Copyright &copy; Your Website 2014
                     </div>
                 </div>
+            </div>
             </div>
         </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
                                 <a href="#" class="btn-social btn-outline"><i class="fa fa-fw fa-dribbble"></i></a>
                             </li>
                             <li>
-                                <a href="#" class ="btn-social btn-outline"><i class="fa fa-fw fa-envelope"></i></a>
+                              <!-- replace '#' with your email-->  <a href="mailto:#" class ="btn-social btn-outline"><i class="fa fa-fw fa-envelope"></i></a>
                             </li>
                         </ul>
                     </div>


### PR DESCRIPTION
I created an alternate version of the template for those that would like to use the theme but don't want to use the contact form. For this version I've removed the contact form and made the footer into the new contact section. Selecting "contact" in the navbar now scrolls to the footer, and there is also a new Envelope icon in the footer that will cause the users email application to be opened with email address already filled in of the site owner. 